### PR TITLE
Add missing quote_ident

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -269,7 +269,7 @@ BEGIN
 
   LOOP
     cnt := cnt + 1;
-    buffer := dest_schema || '.' || quote_ident(object);
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
     IF ddl_only THEN
       RAISE INFO '%', 'CREATE TABLE ' || buffer || ' (LIKE ' || quote_ident(source_schema) || '.' || quote_ident(object) || ' INCLUDING ALL)';
     ELSE
@@ -334,7 +334,7 @@ BEGIN
 
   LOOP
     cnt := cnt + 1;
-    buffer := dest_schema || '.' || quote_ident(object);
+    buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
     SELECT view_definition INTO v_def
       FROM information_schema.views
      WHERE table_schema = quote_ident(source_schema)


### PR DESCRIPTION
Otherwise migrating to a schema that needs quoting leads to syntax error:

```
ERROR:  Action: Views  Diagnostics: line=PL/pgSQL function clone_schema(text,text,boolean,boolean) line 335 at EXECUTE. 42601. syntax error at or near "-"
```