### PR TITLE
Copy unqualified foreign keys

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -305,6 +305,7 @@ BEGIN
   --  add FK constraint
   action := 'FK Constraints';
   cnt := 0;
+  SET search_path = '';
   FOR qry IN
     SELECT 'ALTER TABLE ' || quote_ident(dest_schema) || '.' || quote_ident(rn.relname)
                           || ' ADD CONSTRAINT ' || quote_ident(ct.conname) || ' ' || REPLACE(pg_get_constraintdef(ct.oid), 'REFERENCES ' ||quote_ident(source_schema), 'REFERENCES ' || quote_ident(dest_schema)) || ';'
@@ -322,6 +323,7 @@ BEGIN
       END IF;
     END LOOP;
   RAISE NOTICE '       FKEYS cloned: %', LPAD(cnt::text, 5, ' ');
+  EXECUTE 'SET search_path = ' || quote_ident(source_schema) ;
   
 -- Create views
   action := 'Views';


### PR DESCRIPTION
Because at the beginning we set the schema search path to the source schema, `pg_get_constraintdef` may return unqualified references, and then the replace does not work.

By setting the search path to empty, we force pg to print a qualified reference