### PR TITLE
fix: Update references to data types in functions

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -410,6 +410,7 @@ BEGIN
 -- Create functions
   action := 'Functions';
   cnt := 0;
+  SET search_path = '';
   FOR func_oid IN
     SELECT oid
       FROM pg_proc
@@ -425,6 +426,7 @@ BEGIN
     END IF;
 
   END LOOP;
+  EXECUTE 'SET search_path = ' || quote_ident(source_schema) ;
   RAISE NOTICE '   FUNCTIONS cloned: %', LPAD(cnt::text, 5, ' ');
 
   -- MV: Create Triggers
@@ -624,8 +626,9 @@ BEGIN
   -- MV: PRIVS: functions
   action := 'PRIVS: Functions';
   cnt := 0;
+  EXECUTE 'SET search_path = ' || quote_ident(dest_schema) ;
   FOR arec IN
-    SELECT 'GRANT EXECUTE ON FUNCTION ' || quote_ident(dest_schema) || '.' || regexp_replace(f.oid::regprocedure::text, '^((("[^"]*")|([^"][^.]*))\.)?', '') || ' TO "' || r.rolname || '";' as func_ddl
+    SELECT 'GRANT EXECUTE ON FUNCTION ' || quote_ident(dest_schema) || '.' || replace(regexp_replace(f.oid::regprocedure::text, '^((("[^"]*")|([^"][^.]*))\.)?', ''), source_schema, dest_schema) || ' TO "' || r.rolname || '";' as func_ddl 
     FROM pg_catalog.pg_proc f CROSS JOIN pg_catalog.pg_roles AS r WHERE f.pronamespace::regnamespace::name = quote_ident(source_schema) AND NOT r.rolsuper AND has_function_privilege(r.oid, f.oid, 'EXECUTE')
     order by regexp_replace(f.oid::regprocedure::text, '^((("[^"]*")|([^"][^.]*))\.)?', '')
   LOOP
@@ -639,6 +642,7 @@ BEGIN
 
     END;
   END LOOP;
+  EXECUTE 'SET search_path = ' || quote_ident(source_schema) ;
   RAISE NOTICE '  FUNC PRIVS cloned: %', LPAD(cnt::text, 5, ' ');
 
   -- MV: PRIVS: tables


### PR DESCRIPTION
When cloning triggers, if one of the data types happens to be a table name (we have one `CREATE OR REPLACE FUNCTION format_person_name(people, configurationKey text) RETURNS TEXT AS $$` where `people` is the name of a table) then when cloning the functions and setting up the triggers they will keep a reference to the table on the original schema.

```
> \df
+---------------+-------------------------------------+--------------------+-------------------------------------------------+---------+
| Schema        | Name                                | Result data type   | Argument data types                             | Type    |
|---------------+-------------------------------------+--------------------+-------------------------------------------------+---------|
| inline_test_6 | check_person_display_name_updated   | trigger            |                                                 | trigger |
| inline_test_6 | format_person_name                  | text               | master_large_demo.people, configurationkey text | normal  |
| inline_test_6 | process_new_person_display_name     | trigger            |                                                 | trigger |
| inline_test_6 | process_updated_person_display_name | trigger            |                                                 | trigger |
+---------------+-------------------------------------+--------------------+-------------------------------------------------+---------+
```

After making these changes it causes the definitions of the functions to include the original schema name in the function definition, this then allows us to do a `replace` on the schema so that after cloning the correct table is being referenced.