### PR TITLE
fix: Support running on AWS RDS

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -130,7 +130,7 @@ BEGIN
   FOR arec IN
     SELECT n.nspname as schemaname, a.rolname as ownername , c.collname, c.collprovider,  c.collcollate as locale,
     'CREATE COLLATION ' || quote_ident(dest_schema) || '."' || c.collname || '" (provider = ' || CASE WHEN c.collprovider = 'i' THEN 'icu' WHEN c.collprovider = 'c' THEN 'libc' ELSE '' END || ', locale = ''' || c.collcollate || ''');' as COLL_DDL
-    FROM pg_collation c JOIN pg_namespace n ON (c.collnamespace = n.oid) JOIN pg_authid a ON (c.collowner = a.oid) WHERE n.nspname = quote_ident(source_schema) order by c.collname
+    FROM pg_collation c JOIN pg_namespace n ON (c.collnamespace = n.oid) JOIN pg_roles a ON (c.collowner = a.oid) WHERE n.nspname = quote_ident(source_schema) order by c.collname
   LOOP
     BEGIN
       cnt := cnt + 1;


### PR DESCRIPTION
On RDS you don't have access to the `pg_authid` table, but we can use `pg_roles` instead since it contains mostly the same information but doesn't expose passwords.