### PR TITLE
Fixes index renaming issue when duplicate index exist.

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -519,7 +519,26 @@ BEGIN
       IF ddl_only THEN
         RAISE INFO '%', 'ALTER INDEX ' || quote_ident(dest_schema) || '.'  || quote_ident(ix_new_name) || ' RENAME TO ' || quote_ident(ix_old_name) || ';';
       ELSE
-        EXECUTE 'ALTER INDEX ' || quote_ident(dest_schema) || '.'  || quote_ident(ix_new_name) || ' RENAME TO ' || quote_ident(ix_old_name) || ';';
+        -- The SELECT query above may return duplicate names when a column is
+        -- indexed twice the same manner with 2 different names. Therefore, to
+        -- avoid a 'relation "xxx" already exists' we test if the index name
+        -- is in use or free. Skipping existing index will fallback on unused
+        -- ones and every duplicate will be mapped to distinct old names.
+        IF NOT EXISTS (
+            SELECT TRUE
+            FROM pg_indexes
+            WHERE schemaname = dest_schema
+              AND tablename = tblname
+              AND indexname = quote_ident(ix_old_name))
+          AND EXISTS (
+            SELECT TRUE
+            FROM pg_indexes
+            WHERE schemaname = dest_schema
+              AND tablename = tblname
+              AND indexname = quote_ident(ix_new_name))
+          THEN
+          EXECUTE 'ALTER INDEX ' || quote_ident(dest_schema) || '.' || quote_ident(ix_new_name) || ' RENAME TO ' || quote_ident(ix_old_name) || ';';
+        END IF;
       END IF;
     END LOOP;
 

--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -514,7 +514,7 @@ BEGIN
         AND old.tablename = tblname
         AND old.indexname <> new.indexname
         AND regexp_replace(old.indexdef, E'.*USING','') = regexp_replace(new.indexdef, E'.*USING','')
-        ORDER BY old.indexname, new.indexname
+        ORDER BY old.indexdef, new.indexdef
     LOOP
       IF ddl_only THEN
         RAISE INFO '%', 'ALTER INDEX ' || quote_ident(dest_schema) || '.'  || quote_ident(ix_new_name) || ' RENAME TO ' || quote_ident(ix_old_name) || ';';


### PR DESCRIPTION
Fixes the following issue:
Job execution failed: SQLSTATE[P0001]: Raise exception: 7 ERROR:  Action:
Tables  Diagnostics: line=SQL statement "ALTER INDEX someschema.sometablename_key RENAME TO someoldname_key;"
PL/pgSQL function clone_schema(text,text,boolean,boolean) line 366 at
EXECUTE. 42P07. relation "someoldname_key" already exists

 The SELECT query used to associate new index names with old ones may return duplicate names when a column is indexed twice the same manner with 2 different names. Therefore, to avoid a 'relation "xxx" already exists' we test if the index name is in use or free. Skipping existing index will fallback on unused ones and every duplicate will be mapped to distinct old names.

Mitigation: the error will only appear when 2 indexes are using the same settings with different names. This would mean one of them has been added by mistake and should be removed for performance issues.