### PR TITLE
Added support for aggregate functions

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -699,7 +699,7 @@ BEGIN
       || '('
       || format_type(a.aggtranstype, NULL)
       || ') (sfunc = '
-      || a.aggtransfn
+      || regexp_replace(a.aggtransfn::text, '(^|\W)' || quote_ident(source_schema) || '\.', '\1' || quote_ident(dest_schema) || '.')
       || ', stype = '
       || format_type(a.aggtranstype, NULL)
       || CASE


### PR DESCRIPTION
This fixes the following issue:
Action: Functions  Diagnostics: line=SQL statement "SELECT pg_get_functiondef(func_oid)"
PL/pgSQL function clone_schema(text,text,boolean,boolean) line 537 at SQL statement. 42809. "concat" is an aggregate function
CONTEXT:  PL/pgSQL function clone_schema(text,text,boolean,boolean) line 851 at RAISE
somedb=> SELECT pg_get_functiondef(func_oid);
ERROR:  column "func_oid" does not exist
LINE 1: SELECT pg_get_functiondef(func_oid);
                                  ^

Current implementation does not separate regular function and aggregate functions. However "pg_get_functiondef()" does not work with aggregate functions. Therefore some code has been added to support that.