### PR TITLE
Fixes issue on GRANTs when dealing with agg. func.

### DIFF
--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -923,6 +923,7 @@ BEGIN
     -- order by regexp_replace(f.oid::regprocedure::text, '^((("[^"]*")|([^"][^.]*))\.)?', '')
     
     -- 2021-03-05 MJV FIX: issue#37: defaults cause problems, use system function that returns args WITHOUT DEFAULTS
+    -- COALESCE(r.routine_type, 'FUNCTION'): for aggregate functions, information_schema.routines contains NULL as routine_type value.
     SELECT 'GRANT ' || rp.privilege_type || ' ON ' || COALESCE(r.routine_type, 'FUNCTION') || ' ' || quote_ident(dest_schema) || '.' || rp.routine_name || ' (' || pg_get_function_identity_arguments(p.oid) || ') TO ' || string_agg(distinct rp.grantee, ',') || ';' as func_dcl
     FROM information_schema.routine_privileges rp, information_schema.routines r, pg_proc p, pg_namespace n 
     WHERE rp.routine_schema = quote_ident(source_schema)

--- a/clone_schema.sql
+++ b/clone_schema.sql
@@ -923,10 +923,16 @@ BEGIN
     -- order by regexp_replace(f.oid::regprocedure::text, '^((("[^"]*")|([^"][^.]*))\.)?', '')
     
     -- 2021-03-05 MJV FIX: issue#37: defaults cause problems, use system function that returns args WITHOUT DEFAULTS
-    SELECT 'GRANT ' || rp.privilege_type || ' ON ' || r.routine_type || ' ' || quote_ident(dest_schema) || '.' || rp.routine_name || ' (' || pg_get_function_identity_arguments(p.oid) || ') TO ' || string_agg(distinct rp.grantee, ',') || ';' as func_dcl
+    SELECT 'GRANT ' || rp.privilege_type || ' ON ' || COALESCE(r.routine_type, 'FUNCTION') || ' ' || quote_ident(dest_schema) || '.' || rp.routine_name || ' (' || pg_get_function_identity_arguments(p.oid) || ') TO ' || string_agg(distinct rp.grantee, ',') || ';' as func_dcl
     FROM information_schema.routine_privileges rp, information_schema.routines r, pg_proc p, pg_namespace n 
-    where rp.routine_schema = quote_ident(source_schema) and rp.is_grantable = 'YES' and rp.routine_schema = r.routine_schema and rp.routine_name = r.routine_name and rp.routine_schema = n.nspname and n.oid = p.pronamespace and p.proname = r.routine_name 
-    group by rp.privilege_type, r.routine_type, rp.routine_name, pg_get_function_identity_arguments(p.oid)
+    WHERE rp.routine_schema = quote_ident(source_schema)
+      AND rp.is_grantable = 'YES'
+      AND rp.routine_schema = r.routine_schema
+      AND rp.routine_name = r.routine_name
+      AND rp.routine_schema = n.nspname
+      AND n.oid = p.pronamespace
+      AND p.proname = r.routine_name 
+    GROUP BY rp.privilege_type, r.routine_type, rp.routine_name, pg_get_function_identity_arguments(p.oid)
   LOOP
     BEGIN
       cnt := cnt + 1;


### PR DESCRIPTION
When working with aggregate functions, information_schema.routines contains NULL as routine_type value. Therefore, the query
    SELECT 'GRANT ' || rp.privilege_type || ' ON ' || r.routine_type || ' ' || quote_ident(dest_schema) || '.' || rp.routine_name || ' (' || pg_get_function_identity_arguments(p.oid) || ') TO ' || string_agg(distinct rp.grantee, ',') || ';' as func_dcl
    FROM information_schema.routine_privileges rp, information_schema.routines r, pg_proc p, pg_namespace n 
    where rp.routine_schema = quote_ident(source_schema) and rp.is_grantable = 'YES' and rp.routine_schema = r.routine_schema and rp.routine_name = r.routine_name and rp.routine_schema = n.nspname and n.oid = p.pronamespace and p.proname = r.routine_name 

returns NULL (result of a concatenation with text and NULL) and give the error:
ERROR:  Action: PRIVS: Functions/Procedures  Diagnostics: line=PL/pgSQL function public.clone_schema(text,text,boolean,boolean) line 837 at EXECUTE. 22004. query string argument of EXECUTE is null

Using COALESCE(r.routine_type, 'FUNCTION') solves the problem.